### PR TITLE
Relax required Node version to include Node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/adriantoine/enzyme-to-json.git"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=4.0.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Travis is already setup to test with Node.js v4, however, the node
engine property in package.json requests Node v6. npm will log a warning
when it encounters an engine property that doesn't match, but yarn will
fail the install.