### PR TITLE
docs: Rewrite setState with function argument in first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class MyComponent extends Component {
   }
 
   handleClick() {
-    this.setState({ count: this.state.count + 1 });
+    this.setState(({ count }) => ({ count: count + 1 }));
   }
 
   render() {

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -12,7 +12,7 @@ class MyComponent extends Component {
     }
 
     handleClick() {
-        this.setState({ count: this.state.count + 1 });
+        this.setState(({ count }) => ({ count: count + 1 }));
     }
 
     render() {


### PR DESCRIPTION
This small change is off the main point of the example code :)

However, while learning React, I have often followed even small details of clearly-written examples like this without clearly understanding what I was doing. If I understand correctly, a function argument is now the public recommendation when next state depends on previous state:

https://facebook.github.io/react/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous