### PR TITLE
docs: Add example to simulate click and then match snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,28 @@ exports[`test renders correctly 1`] = `
 </div>
 `;
 ```
-It becomes especially handy as you can use all [Enzyme](http://airbnb.io/enzyme/) features like `find` or `setState`:
+It becomes especially handy as you can use all [Enzyme](http://airbnb.io/enzyme/) features like `find`, `simulate`, or `setState`:
+```js
+it('renders span after click', () => {
+  const wrapper = shallow(
+    <MyComponent className="my-component">
+      <strong>Hello World!</strong>
+    </MyComponent>
+  );
+
+  wrapper.find('div').simulate('click');
+  expect(shallowToJson(wrapper.find('span'))).toMatchSnapshot();
+});
+
+// generates:
+
+exports[`test renders span after click 1`] = `
+<span
+  className="count">
+  2
+</span>
+`;
+```
 ```js
 it('renders span after setState', () => {
   const wrapper = shallow(


### PR DESCRIPTION
Thinking more how I follow clear and short examples:

What do you think about an example of changing the state by simulating an event to contrast with calling `setState` directly in the existing example?

Some blog articles that I have read debate how much to call lifecycle methods in tests.