### PR TITLE
renderToJson return null when a component returns null

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,7 @@
 import compact from 'lodash.compact';
 
 const renderChildToJson = child => {
-    if(!child) return;
+    if(!child) return null;
 
     if(child.type === 'tag') {
         return {

--- a/tests/core/__snapshots__/mount.test.js.snap
+++ b/tests/core/__snapshots__/mount.test.js.snap
@@ -179,6 +179,8 @@ exports[`test converts pure mount with mixed children 1`] = `
 </BasicPure>
 `;
 
+exports[`test handles a component which returns null 1`] = `<ClassWithNull />`;
+
 exports[`test skips undefined props 1`] = `
 <BasicWithUndefined>
   <button>

--- a/tests/core/__snapshots__/render.test.js.snap
+++ b/tests/core/__snapshots__/render.test.js.snap
@@ -31,3 +31,5 @@ exports[`test converts basic pure render 1`] = `
   </div>
 </div>
 `;
+
+exports[`test handles a component which returns null 1`] = `null`;

--- a/tests/core/mount.test.js
+++ b/tests/core/mount.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { mountToJson } from '../../src';
 import { BasicPure, BasicWithUndefined } from './fixtures/pure-function';
-import { BasicClass, ClassWithPure, ClassWithDirectPure, ClassWithDirectComponent } from './fixtures/class';
+import { BasicClass, ClassWithPure, ClassWithDirectPure, ClassWithDirectComponent, ClassWithNull } from './fixtures/class';
 
 it('converts basic pure mount', () => {
     const mounted = mount(
@@ -55,6 +55,14 @@ it('converts a class mount with a pure function in it as a direct child', () => 
 it('converts a class mount with a class component in it as a direct child', () => {
     const mounted = mount(
         <ClassWithDirectComponent className="class"><strong>Hello!</strong></ClassWithDirectComponent>
+    );
+
+    expect(mountToJson(mounted)).toMatchSnapshot();
+});
+
+it('handles a component which returns null', () => {
+    const mounted = mount(
+        <ClassWithNull />
     );
 
     expect(mountToJson(mounted)).toMatchSnapshot();

--- a/tests/core/render.test.js
+++ b/tests/core/render.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { renderToJson } from '../../src';
 import { BasicPure } from './fixtures/pure-function';
-import { BasicClass } from './fixtures/class';
+import { BasicClass, ClassWithNull } from './fixtures/class';
 
 it('converts basic pure render', () => {
     const rendered = render(
@@ -17,6 +17,14 @@ it('converts basic pure render', () => {
 it('converts basic class render', () => {
     const rendered = render(
         <BasicClass className="class"><strong>Hello!</strong></BasicClass>
+    );
+
+    expect(renderToJson(rendered)).toMatchSnapshot();
+});
+
+it('handles a component which returns null', () => {
+    const rendered = render(
+      <ClassWithNull />
     );
 
     expect(renderToJson(rendered)).toMatchSnapshot();


### PR DESCRIPTION
* Return an explicit `null` value instead of implicit `undefined` value so that `renderToJson` is consistent with `shallowToJson`
* Added test for `renderToJson` (and also for `mountToJson` to assert its behavior) compare to https://github.com/adriantoine/enzyme-to-json/blob/master/tests/core/shallow.test.js#L36-L41