### PR TITLE
allow multiple nodes to be rendered to JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"lodash.isnil": "^4.0.0",
 		"lodash.isplainobject": "^4.0.6",
 		"lodash.omitby": "^4.5.0",
+		"lodash.range": "^3.2.0",
 		"object-values": "^1.0.0",
 		"object.entries": "^1.0.3"
 	},

--- a/src/mount.js
+++ b/src/mount.js
@@ -60,4 +60,8 @@ function instToJson(inst) {
   };
 }
 
-export default wrapper => instToJson(wrapper.node);
+export default wrapper => {
+  return wrapper.length > 1
+    ? wrapper.nodes.map(instToJson)
+    : instToJson(wrapper.node);
+};

--- a/src/render.js
+++ b/src/render.js
@@ -1,3 +1,4 @@
+import range from 'lodash.range';
 import {compact} from './utils';
 
 const renderChildToJson = child => {
@@ -23,4 +24,8 @@ const renderChildToJson = child => {
   }
 };
 
-export default wrapper => renderChildToJson(wrapper[0]);
+export default wrapper => {
+  return wrapper.length > 1
+    ? range(0, wrapper.length).map(node => renderChildToJson(wrapper[node]))
+    : renderChildToJson(wrapper[0])
+}

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -46,4 +46,8 @@ function nodeToJson(node) {
   };
 }
 
-export default wrapper => nodeToJson(wrapper.node);
+export default wrapper => {
+  return wrapper.length > 1
+    ? wrapper.nodes.map(nodeToJson)
+    : nodeToJson(wrapper.node);
+};

--- a/tests/core/__snapshots__/mount.test.js.snap
+++ b/tests/core/__snapshots__/mount.test.js.snap
@@ -181,6 +181,17 @@ exports[`test converts pure mount with mixed children 1`] = `
 
 exports[`test handles a component which returns null 1`] = `<ClassWithNull />`;
 
+exports[`test renders multiple elements as a result of find 1`] = `
+Array [
+  <li>
+    0
+</li>,
+  <li>
+    1
+</li>,
+]
+`;
+
 exports[`test renders zero-children 1`] = `
 <ComponentWithAZeroChildren>
   <div>

--- a/tests/core/__snapshots__/render.test.js.snap
+++ b/tests/core/__snapshots__/render.test.js.snap
@@ -32,6 +32,19 @@ exports[`test converts basic pure render 1`] = `
 </div>
 `;
 
+exports[`test handles a component which returns null 1`] = `null`;
+
+exports[`test renders multiple elements as a result of find 1`] = `
+Array [
+  <li>
+    0
+</li>,
+  <li>
+    1
+</li>,
+]
+`;
+
 exports[`test renders the whole list 1`] = `
 <ul>
   <li>
@@ -42,5 +55,3 @@ exports[`test renders the whole list 1`] = `
   </li>
 </ul>
 `;
-
-exports[`test handles a component which returns null 1`] = `null`;

--- a/tests/core/__snapshots__/shallow.test.js.snap
+++ b/tests/core/__snapshots__/shallow.test.js.snap
@@ -106,6 +106,17 @@ exports[`test ignores non-plain objects 1`] = `
   } />
 `;
 
+exports[`test renders multiple elements as a result of find 1`] = `
+Array [
+  <li>
+    0
+</li>,
+  <li>
+    1
+</li>,
+]
+`;
+
 exports[`test skips undefined props 1`] = `
 <button>
   Hello

--- a/tests/core/mount.test.js
+++ b/tests/core/mount.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import {mountToJson} from '../../src';
-import {BasicPure, BasicWithUndefined, ComponentWithAZeroChildren} from './fixtures/pure-function';
+import {BasicPure, BasicWithUndefined, BasicWithAList, ComponentWithAZeroChildren} from './fixtures/pure-function';
 import {
   BasicClass,
   ClassWithPure,
@@ -71,4 +71,9 @@ it('skips undefined props', () => {
 it('renders zero-children', () => {
   const mounted = mount(<ComponentWithAZeroChildren />);
   expect(mountToJson(mounted)).toMatchSnapshot();
+});
+
+it('renders multiple elements as a result of find', () => {
+  const mounted = mount(<BasicWithAList />);
+  expect(mountToJson(mounted.find('li'))).toMatchSnapshot();
 });

--- a/tests/core/render.test.js
+++ b/tests/core/render.test.js
@@ -28,3 +28,8 @@ it('handles a component which returns null', () => {
 
   expect(renderToJson(rendered)).toMatchSnapshot();
 });
+
+it('renders multiple elements as a result of find', () => {
+  const rendered = render(<BasicWithAList />);
+  expect(renderToJson(rendered.find('li'))).toMatchSnapshot();
+});

--- a/tests/core/shallow.test.js
+++ b/tests/core/shallow.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {shallowToJson} from '../../src';
-import {BasicPure, BasicWithUndefined} from './fixtures/pure-function';
+import {BasicPure, BasicWithUndefined, BasicWithAList} from './fixtures/pure-function';
 import {BasicClass, ClassWithPure, ClassWithNull} from './fixtures/class';
 
 function WrapperComponent(props) {
@@ -75,4 +75,9 @@ it('skips undefined props', () => {
   const shallowed = shallow(<BasicWithUndefined>Hello!</BasicWithUndefined>);
 
   expect(shallowToJson(shallowed)).toMatchSnapshot();
+});
+
+it('renders multiple elements as a result of find', () => {
+  const shallowed = shallow(<BasicWithAList />);
+  expect(shallowToJson(shallowed.find('li'))).toMatchSnapshot();
 });


### PR DESCRIPTION
This will allow multiple nodes to be rendered to JSON if they are received as a result of `find`.
Fixes #40 