### PR TITLE
[WIP] Map functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 		"lint": "eslint src tests/core",
 		"format": "prettier src/**/*.js tests/core/**/*.js --write --print-width=100 --single-quote --trailing-comma --no-bracket-spacing",
 		"test": "npm run lint && npm run test-core && npm run test-serializer",
-		"test-core": "NODE_ENV=test jest --coverage",
-		"test-serializer": "cd tests/serializer && rm -rf node_modules && npm install && npm test",
+		"test-core": "cross-env NODE_ENV=test jest --coverage",
+		"test-serializer": "cd tests/serializer && rimraf node_modules && npm install && npm test",
 		"semantic-release": "semantic-release pre && npm publish && semantic-release post"
 	},
 	"keywords": [
@@ -57,6 +57,7 @@
 		"babel-preset-es2015": "^6.22.0",
 		"babel-preset-react": "^6.22.0",
 		"codecov": "^1.0.1",
+		"cross-env": "^3.1.4",
 		"cz-conventional-changelog": "^1.2.0",
 		"enzyme": "^2.7.1",
 		"eslint": "^3.15.0",
@@ -72,6 +73,7 @@
 		"react": "^15.4.2",
 		"react-addons-test-utils": "^15.4.2",
 		"react-dom": "^15.4.2",
+		"rimraf": "^2.6.1",
 		"semantic-release": "^6.3.2"
 	},
 	"jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ import shallowToJson from './shallow';
 import mountToJson from './mount';
 import renderToJson from './render';
 
-export default function(wrapper) {
+export default function(wrapper, options) {
   if (isShallowWrapper(wrapper)) {
-    return shallowToJson(wrapper);
+    return shallowToJson(wrapper, options);
   }
 
   if (isReactWrapper(wrapper)) {

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -7,46 +7,55 @@ import {childrenOfNode} from 'enzyme/build/ShallowTraversal';
 import {isElement} from 'enzyme/build/react-compat';
 import {compact} from './utils';
 
-function nodeToJson(node) {
-  if (!node) {
-    return node;
-  }
+export default (wrapper, options) => {
 
-  if (typeof node === 'string' || typeof node === 'number') {
-    return node;
-  }
+  options = Object.assign({}, options)
 
-  if (!isElement(node)) {
-    if (Array.isArray(node)) {
-      return node.map(nodeToJson);
+  function nodeToJson(node) {
+    if (!node) {
+      return node;
     }
 
-    if (isPlainObject(node)) {
-      return entries(node).reduce(
-        (obj, [key, val]) => {
-          obj[key] = nodeToJson(val);
-          return obj;
-        },
-        {},
-      );
+    if (typeof node === 'string' || typeof node === 'number') {
+      return node;
     }
 
-    return node;
+    if (!isElement(node)) {
+      if (Array.isArray(node)) {
+        return node.map(nodeToJson);
+      }
+
+      if (isPlainObject(node)) {
+        return entries(node).reduce(
+          (obj, [key, val]) => {
+            obj[key] = nodeToJson(val);
+            return obj;
+          },
+          {},
+        );
+      }
+
+      return node;
+    }
+
+    const children = compact(childrenOfNode(node).map(n => nodeToJson(n)));
+    const type = typeName(node);
+    const props = omitBy(propsOfNode(node), (val, key) => key === 'children' || val === undefined);
+
+    let json = {
+      type,
+      props: nodeToJson(props),
+      children: children.length ? children : null,
+      $$typeof: Symbol.for('react.test.json'),
+    };
+
+    if (options.map) {
+      json = options.map(node, json)
+    }
+
+    return json;
   }
 
-  const children = compact(childrenOfNode(node).map(n => nodeToJson(n)));
-  const type = typeName(node);
-  const props = omitBy(propsOfNode(node), (val, key) => key === 'children' || val === undefined);
-
-  return {
-    type,
-    props: nodeToJson(props),
-    children: children.length ? children : null,
-    $$typeof: Symbol.for('react.test.json'),
-  };
-}
-
-export default wrapper => {
   return wrapper.length > 1
     ? wrapper.nodes.map(nodeToJson)
     : nodeToJson(wrapper.node);

--- a/tests/core/__snapshots__/shallow.test.js.snap
+++ b/tests/core/__snapshots__/shallow.test.js.snap
@@ -106,6 +106,8 @@ exports[`test ignores non-plain objects 1`] = `
   } />
 `;
 
+exports[`test maps output 1`] = `<BasicClass />`;
+
 exports[`test renders multiple elements as a result of find 1`] = `
 Array [
   <li>

--- a/tests/core/fixtures/class.js
+++ b/tests/core/fixtures/class.js
@@ -57,3 +57,26 @@ export class ClassWithNull extends Component {
     return null;
   }
 }
+
+function wrap(WrappedClass) {
+  class WrapperClass extends Component {
+    render() {
+      return <WrappedClass />
+    }
+  }
+
+  const displayName = WrappedClass.name;
+
+  WrapperClass.displayName = `Wrapper(${displayName})`;
+  WrapperClass.WrappedClass = WrappedClass;
+
+  return WrapperClass;
+}
+
+const WrappedClass = wrap(BasicClass);
+
+export class ClassWithHOC extends Component {
+  render() {
+    return <WrappedClass />
+  }
+}

--- a/tests/core/index.test.js
+++ b/tests/core/index.test.js
@@ -15,10 +15,11 @@ import toJson from '../../src';
 
 it('runs shallowToJson when a shallow wrapper is passed', () => {
   const shallowed = shallow(<div>test</div>);
-  toJson(shallowed);
+  const options = {};
+  toJson(shallowed, options);
 
   expect(shallowToJson).toHaveBeenCalledTimes(1);
-  expect(shallowToJson).toHaveBeenCalledWith(shallowed);
+  expect(shallowToJson).toHaveBeenCalledWith(shallowed, options);
 });
 
 it('runs mountToJson when a mount wrapper is passed', () => {

--- a/tests/core/shallow.test.js
+++ b/tests/core/shallow.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {shallowToJson} from '../../src';
 import {BasicPure, BasicWithUndefined, BasicWithAList} from './fixtures/pure-function';
-import {BasicClass, ClassWithPure, ClassWithNull} from './fixtures/class';
+import {BasicClass, ClassWithPure, ClassWithNull, ClassWithHOC} from './fixtures/class';
 
 function WrapperComponent(props) {
   return <BasicPure {...props} />;
@@ -81,3 +81,14 @@ it('renders multiple elements as a result of find', () => {
   const shallowed = shallow(<BasicWithAList />);
   expect(shallowToJson(shallowed.find('li'))).toMatchSnapshot();
 });
+
+it ('maps output', () => {
+  const shallowed = shallow(<ClassWithHOC />);
+  const map = (node, json) => {
+    if (node.type.WrappedClass) {
+      json.type = node.type.WrappedClass.name;
+    }
+    return json;
+  };
+  expect(shallowToJson(shallowed, { map })).toMatchSnapshot();
+})


### PR DESCRIPTION
Addresses #48 

Instead of trying to explain what I meant I figured I'd just show. This is a partial implementation that only covers shallow rendering. In the added unit test, if mapping functionality was not available, the output would show `<Wrapper(BasicClass) />`. With mapping we are able to unwrap the class and set the display to whatever we want. Of course the mapping would also allow many other kinds of modifications like changing props, children, etc.

If you like this concept I can continue fleshing it out.

One big question I have is how you could pass options to the serializer, especially something like a mapping function.

Oh, and since I work on a Windows machine I needed to make a couple changes to allow the tests to run on Windows.