### PR TITLE
Fixed typescript implicit any type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,8 +19,8 @@ export interface Options {
 }
 
 export interface JestSerializer {
-  test: (CommonWrapper) => boolean;
-  print: (CommonWrapper, serializer) => Json;
+  test: (CommonWrapper: CommonWrapper) => boolean;
+  print: (CommonWrapper: CommonWrapper, serializer: JestSerializer) => Json;
 }
 
 /**


### PR DESCRIPTION
Because typescript compiler will fail because of implicit any type.