### PR TITLE
Fix deep mounting of arrays

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -42,6 +42,10 @@ function internalNodeToJson(node, options) {
     return '';
   }
 
+  if (Array.isArray(node)) {
+    return node.map(child => internalNodeToJson(child, options));
+  }
+
   if (options.mode === 'deep' && typeof node.type === 'function') {
     return internalNodeToJson(node.rendered, options);
   }

--- a/tests/__snapshots__/mount-deep.test.js.snap
+++ b/tests/__snapshots__/mount-deep.test.js.snap
@@ -135,6 +135,31 @@ exports[`converts basic pure mount 1`] = `
 </div>
 `;
 
+exports[`converts class components with render returning top level arrays 1`] = `
+Array [
+  <div
+    className="test"
+    key="test"
+  >
+    Test
+  </div>,
+  <div
+    className="test2"
+    key="test2"
+  >
+    Test 2
+  </div>,
+  <div
+    className="child"
+    key="child"
+  >
+    <strong>
+      Hello!
+    </strong>
+  </div>,
+]
+`;
+
 exports[`converts class mount with mixed children 1`] = `
 <div
   className="basic-class undefined"
@@ -154,6 +179,31 @@ exports[`converts class mount with mixed children 1`] = `
     />
   </div>
 </div>
+`;
+
+exports[`converts function components with render returning top level arrays 1`] = `
+Array [
+  <div
+    className="test"
+    key="test"
+  >
+    Test
+  </div>,
+  <div
+    className="test2"
+    key="test2"
+  >
+    Test 2
+  </div>,
+  <div
+    className="child"
+    key="child"
+  >
+    <strong>
+      Hello!
+    </strong>
+  </div>,
+]
 `;
 
 exports[`converts pure mount with mixed children 1`] = `

--- a/tests/mount-deep.test.js
+++ b/tests/mount-deep.test.js
@@ -9,6 +9,7 @@ import {
   BasicWithUndefined,
   BasicWithAList,
   ComponentWithAZeroChildren,
+  ArrayRender,
 } from './fixtures/pure-function';
 import {
   BasicClass,
@@ -16,6 +17,7 @@ import {
   ClassWithDirectPure,
   ClassWithDirectComponent,
   ClassWithNull,
+  ClassArrayRender,
 } from './fixtures/class';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -78,6 +80,26 @@ it('converts a class mount with a class component in it as a direct child', () =
     <ClassWithDirectComponent className="class">
       <strong>Hello!</strong>
     </ClassWithDirectComponent>,
+  );
+
+  expect(mountToJson(mounted, deepOptions)).toMatchSnapshot();
+});
+
+it('converts function components with render returning top level arrays', () => {
+  const mounted = mount(
+    <ArrayRender>
+      <strong>Hello!</strong>
+    </ArrayRender>,
+  );
+
+  expect(mountToJson(mounted, deepOptions)).toMatchSnapshot();
+});
+
+it('converts class components with render returning top level arrays', () => {
+  const mounted = mount(
+    <ClassArrayRender>
+      <strong>Hello!</strong>
+    </ClassArrayRender>,
   );
 
   expect(mountToJson(mounted, deepOptions)).toMatchSnapshot();


### PR DESCRIPTION
Currently if I try to mount a component that returns an array with a mode set to `deep` I get `<undefined/>`. This PR fixes it.