### PR TITLE
Pass node to map function

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -52,6 +52,7 @@ function internalNodeToJson(node, options) {
 
   return applyMap(
     {
+      node,
       type: typeName(node),
       props: getProps(node, options),
       children: getChildren(node, options),

--- a/src/render.js
+++ b/src/render.js
@@ -10,6 +10,7 @@ const renderChildToJson = (child, options) => {
   if (child.type === 'tag') {
     return applyMap(
       {
+        node: child,
         type: child.name,
         props: child.attribs,
         children: compact(

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -46,6 +46,7 @@ function internalNodeToJson(node, options) {
 
   const json = applyMap(
     {
+      node,
       type: typeName(node),
       props: getProps(node, options),
       children: getChildren(node, options),


### PR DESCRIPTION
This fixes #82.

Basically, it turns out it's really useful to have more information available in `map`, so let's give those monsters what they want.