### PR TITLE
fix: Skip undefined props in snapshots

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -23,7 +23,9 @@ function getProps(node, options) {
     {
       ...propsOfNode(node),
     },
-    (val, key) => key === 'children',
+    (val, key) => {
+      return key === 'children' || val === undefined;
+    },
   );
 
   if (!isNil(node.key) && options.noKey !== true) {

--- a/tests/__snapshots__/mount-deep.test.js.snap
+++ b/tests/__snapshots__/mount-deep.test.js.snap
@@ -230,9 +230,7 @@ exports[`converts pure mount with mixed children 1`] = `
 exports[`handles a component which returns null 1`] = `""`;
 
 exports[`includes undefined props 1`] = `
-<button
-  disabled={undefined}
->
+<button>
   Hello
 </button>
 `;

--- a/tests/__snapshots__/mount-shallow.test.js.snap
+++ b/tests/__snapshots__/mount-shallow.test.js.snap
@@ -122,9 +122,7 @@ exports[`converts pure mount with mixed children 1`] = `
 exports[`handles a component which returns null 1`] = `null`;
 
 exports[`includes undefined props 1`] = `
-<button
-  disabled={undefined}
->
+<button>
   Hello
 </button>
 `;

--- a/tests/__snapshots__/mount.test.js.snap
+++ b/tests/__snapshots__/mount.test.js.snap
@@ -455,9 +455,7 @@ exports[`renders zero-children 1`] = `
 
 exports[`skips undefined props 1`] = `
 <BasicWithUndefined>
-  <button
-    disabled={undefined}
-  >
+  <button>
     Hello
   </button>
 </BasicWithUndefined>


### PR DESCRIPTION
It seems like the snapshots where overwritten when updating to Enzyme 3 and React 16.