### PR TITLE
Add overloads with generic parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,16 +29,15 @@ export interface JestSerializer {
  * @param [options] an option object which accepts `map`, `noKey` and `mode` as keys
  */
 declare function toJson(wrapper: CommonWrapper, options?: Options): Json;
+declare function toJson<P, S>(wrapper: CommonWrapper<P, S>, options?: Options): Json;
 
 /**
  * shallowToJson helper is used to convert Enzyme shallow wrappers to a format compatible with Jest snapshot
  * @param wrapper an Enzyme shallow wrapper
  * @param [options] an option object which accepts `map`, `noKey` and `mode` as keys
  */
-declare function shallowToJson(
-  wrapper: ShallowWrapper,
-  options?: Options,
-): Json;
+declare function shallowToJson(wrapper: ShallowWrapper, options?: Options,): Json;
+declare function shallowToJson<P, S>(wrapper: ShallowWrapper<P, S>, options?: Options,): Json;
 
 /**
  * mountToJson helper is used to convert Enzyme mount wrappers to a format compatible with Jest snapshot
@@ -46,6 +45,7 @@ declare function shallowToJson(
  * @param [options] an option object which accepts `map`, `noKey` and `mode` as keys
  */
 declare function mountToJson(wrapper: ReactWrapper, options?: Options): Json;
+declare function mountToJson<P, S>(wrapper: ReactWrapper<P, S>, options?: Options): Json;
 
 /**
  * renderToJson helper is used to convert Enzyme render wrappers to a format compatible with Jest snapshot


### PR DESCRIPTION
Due to the new typing rules of TypeScript 2.6 for functions, one need to specify an overload with generic parameters for `toJson`, `mountToJson` and `shallowToJson`.