### PR TITLE
bugfix(default-props): excludes default props from snapshops in shallow mode

### DIFF
--- a/src/shallow.js
+++ b/src/shallow.js
@@ -18,10 +18,20 @@ function getChildren(node, options) {
 }
 
 function getProps(node, options) {
-  const props = omitBy(
-    Object.assign({}, propsOfNode(node)),
-    (val, key) => key === 'children' || val === undefined,
-  );
+  const props = omitBy(Object.assign({}, propsOfNode(node)), (val, key) => {
+    if (key === 'children' || val === undefined) {
+      return true;
+    }
+
+    if (
+      typeof node.type === 'function' &&
+      node.type.defaultProps &&
+      node.type.defaultProps[key] &&
+      node.type.defaultProps[key] === val
+    ) {
+      return true;
+    }
+  });
 
   if (!isNil(node.key) && options.noKey !== true) {
     props.key = node.key;

--- a/tests/__snapshots__/shallow.test.js.snap
+++ b/tests/__snapshots__/shallow.test.js.snap
@@ -245,6 +245,34 @@ Array [
 ]
 `;
 
+exports[`should not bleed default props from class child component into snapshot 1`] = `
+<span>
+  <ClassWithDefaultProps />
+</span>
+`;
+
+exports[`should not bleed default props from funtional child component into snapshot 1`] = `
+<span>
+  <WithDefaultProps />
+</span>
+`;
+
+exports[`should set prop that has a different value from default prop values of class component 1`] = `
+<span>
+  <ClassWithDefaultProps
+    value="ah, man"
+  />
+</span>
+`;
+
+exports[`should set prop that has a different value from default prop values of functional component 1`] = `
+<span>
+  <WithDefaultProps
+    value="yeah, man"
+  />
+</span>
+`;
+
 exports[`skips undefined props 1`] = `
 <button>
   Hello

--- a/tests/fixtures/class.js
+++ b/tests/fixtures/class.js
@@ -103,3 +103,13 @@ export class ClassArrayRender extends Component {
     ];
   }
 }
+
+export class ClassWithDefaultProps extends Component {
+  render() {
+    return <div>{this.props.value}</div>;
+  }
+}
+
+ClassWithDefaultProps.defaultProps = {
+  value: 'hi mum',
+};

--- a/tests/fixtures/pure-function.js
+++ b/tests/fixtures/pure-function.js
@@ -72,3 +72,11 @@ export const FragmentAsRoot = () => (
     <button />
   </React.Fragment>
 );
+
+export const ComponentWithChildren = ({children}) => <span>{children}</span>;
+
+export const WithDefaultProps = ({value}) => <div>{value}</div>;
+
+WithDefaultProps.defaultProps = {
+  value: 'hi there',
+};

--- a/tests/shallow.test.js
+++ b/tests/shallow.test.js
@@ -14,12 +14,15 @@ import {
   FalsyChildren,
   FragmentAsChild,
   FragmentAsRoot,
+  WithDefaultProps,
+  ComponentWithChildren,
 } from './fixtures/pure-function';
 import {
   BasicClass,
   ClassWithPure,
   ClassWithNull,
   ClassArrayRender,
+  ClassWithDefaultProps,
 } from './fixtures/class';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -122,7 +125,9 @@ it('ignores non-plain objects', () => {
     this._test = true;
   }
 
-  const shallowed = shallow(<WrapperComponent instance={new TestConstructor()} />);
+  const shallowed = shallow(
+    <WrapperComponent instance={new TestConstructor()} />,
+  );
 
   expect(shallowToJson(shallowed)).toMatchSnapshot();
 });
@@ -263,6 +268,46 @@ it('renders a component that has a child fragment', () => {
 
 it('renders a component that has a fragment root', () => {
   const wrapper = shallow(<FragmentAsRoot />);
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should not bleed default props from funtional child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <WithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should set prop that has a different value from default prop values of functional component', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <WithDefaultProps value="yeah, man" />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should not bleed default props from class child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ClassWithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should set prop that has a different value from default prop values of class component', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ClassWithDefaultProps value="ah, man" />
+    </ComponentWithChildren>,
+  );
 
   expect(shallowToJson(wrapper)).toMatchSnapshot();
 });


### PR DESCRIPTION
Closes #55 

Atm I'm checking if the default props exists, and if it has the same value in props, then omit it.

This isn't a perfect solution though - what happens if someone passes down a prop that is the same value as the default prop? Semantically we shouldn't omit it then, but this logic will.

Let me know if you can think of another angle we should take.