### PR TITLE
fix incorrect key checking in default-props branch

### DIFF
--- a/src/shallow.js
+++ b/src/shallow.js
@@ -26,7 +26,7 @@ function getProps(node, options) {
     if (
       typeof node.type === 'function' &&
       node.type.defaultProps &&
-      node.type.defaultProps[key] &&
+      key in node.type.defaultProps &&
       node.type.defaultProps[key] === val
     ) {
       return true;

--- a/tests/fixtures/class.js
+++ b/tests/fixtures/class.js
@@ -106,10 +106,11 @@ export class ClassArrayRender extends Component {
 
 export class ClassWithDefaultProps extends Component {
   render() {
-    return <div>{this.props.value}</div>;
+    return <div>{this.props.value},{this.props.falsyValue}</div>;
   }
 }
 
 ClassWithDefaultProps.defaultProps = {
   value: 'hi mum',
+  falsyValue: false,
 };


### PR DESCRIPTION
use key in defaultProps instead of defaultProps[key] to avoid evaluate condition as true for falsy value