### PR TITLE
Add options to disable default props in snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ And here are all the possible options:
 | `noKey` | `bool` | Since `v2.0.0`, the `key` prop is included in the snapshot, you can turn it off if you don't want your key to be in your snapshot by settting this option to `true`. Only works for the `mount` and `shallow` wrappers. |
 | `mode` | `'deep'`, `'shallow'` | The `deep` option will return a test object rendered to **maximum** depth while the `shallow` option will return a test object rendered to **minimum** depth. Only works for the `mount` wrappers. See `mode` documentation for examples. |
 | `map` | `function` | You can change each nested node of your component output by providing the map option. See `map` documentation for examples. |
+| `ignoreDefaultProps` | `bool` | You can exclude the default props from snapshots in shallow mode |
 
 # Docs
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ export interface OutputMapper {
 }
 
 export interface Options {
+  ignoreDefaultProps?: boolean;
   map?: OutputMapper;
   noKey?: boolean;
   mode?: 'shallow' | 'deep';

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -26,7 +26,7 @@ function getProps(node, options) {
     if (
       typeof node.type === 'function' &&
       node.type.defaultProps &&
-      node.type.defaultProps[key] &&
+      key in node.type.defaultProps &&
       node.type.defaultProps[key] === val
     ) {
       return true;

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -24,6 +24,7 @@ function getProps(node, options) {
     }
 
     if (
+      options.ignoreDefaultProps === true &&
       typeof node.type === 'function' &&
       node.type.defaultProps &&
       key in node.type.defaultProps &&

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -18,10 +18,20 @@ function getChildren(node, options) {
 }
 
 function getProps(node, options) {
-  const props = omitBy(
-    Object.assign({}, propsOfNode(node)),
-    (val, key) => key === 'children' || val === undefined,
-  );
+  const props = omitBy(Object.assign({}, propsOfNode(node)), (val, key) => {
+    if (key === 'children' || val === undefined) {
+      return true;
+    }
+
+    if (
+      typeof node.type === 'function' &&
+      node.type.defaultProps &&
+      node.type.defaultProps[key] &&
+      node.type.defaultProps[key] === val
+    ) {
+      return true;
+    }
+  });
 
   if (!isNil(node.key) && options.noKey !== true) {
     props.key = node.key;

--- a/tests/__snapshots__/shallow.test.js.snap
+++ b/tests/__snapshots__/shallow.test.js.snap
@@ -284,13 +284,31 @@ Array [
 ]
 `;
 
+exports[`should bleed default props from class child component into snapshot without the option 1`] = `
+<span>
+  <ClassWithDefaultProps
+    falsyValue={false}
+    value="hi mum"
+  />
+</span>
+`;
+
+exports[`should bleed default props from functional child component into snapshot without the option 1`] = `
+<span>
+  <WithDefaultProps
+    falsyValue={false}
+    value="hi there"
+  />
+</span>
+`;
+
 exports[`should not bleed default props from class child component into snapshot 1`] = `
 <span>
   <ClassWithDefaultProps />
 </span>
 `;
 
-exports[`should not bleed default props from funtional child component into snapshot 1`] = `
+exports[`should not bleed default props from functional child component into snapshot 1`] = `
 <span>
   <WithDefaultProps />
 </span>

--- a/tests/__snapshots__/shallow.test.js.snap
+++ b/tests/__snapshots__/shallow.test.js.snap
@@ -284,6 +284,34 @@ Array [
 ]
 `;
 
+exports[`should not bleed default props from class child component into snapshot 1`] = `
+<span>
+  <ClassWithDefaultProps />
+</span>
+`;
+
+exports[`should not bleed default props from funtional child component into snapshot 1`] = `
+<span>
+  <WithDefaultProps />
+</span>
+`;
+
+exports[`should set prop that has a different value from default prop values of class component 1`] = `
+<span>
+  <ClassWithDefaultProps
+    value="ah, man"
+  />
+</span>
+`;
+
+exports[`should set prop that has a different value from default prop values of functional component 1`] = `
+<span>
+  <WithDefaultProps
+    value="yeah, man"
+  />
+</span>
+`;
+
 exports[`skips undefined props 1`] = `
 <button>
   Hello

--- a/tests/fixtures/class.js
+++ b/tests/fixtures/class.js
@@ -106,10 +106,11 @@ export class ClassArrayRender extends Component {
 
 export class ClassWithDefaultProps extends Component {
   render() {
-    return <div>{this.props.value}</div>;
+    return <div>{this.props.value},{this.props.falsyValue}</div>;
   }
 }
 
 ClassWithDefaultProps.defaultProps = {
   value: 'hi mum',
+  falsyValue: false,
 };

--- a/tests/fixtures/class.js
+++ b/tests/fixtures/class.js
@@ -103,3 +103,13 @@ export class ClassArrayRender extends Component {
     ];
   }
 }
+
+export class ClassWithDefaultProps extends Component {
+  render() {
+    return <div>{this.props.value}</div>;
+  }
+}
+
+ClassWithDefaultProps.defaultProps = {
+  value: 'hi mum',
+};

--- a/tests/fixtures/pure-function.js
+++ b/tests/fixtures/pure-function.js
@@ -100,3 +100,11 @@ export const ComponentWithMemo = () => (
     <Memo />
   </div>
 );
+
+export const ComponentWithChildren = ({children}) => <span>{children}</span>;
+
+export const WithDefaultProps = ({value}) => <div>{value}</div>;
+
+WithDefaultProps.defaultProps = {
+  value: 'hi there',
+};

--- a/tests/fixtures/pure-function.js
+++ b/tests/fixtures/pure-function.js
@@ -103,8 +103,9 @@ export const ComponentWithMemo = () => (
 
 export const ComponentWithChildren = ({children}) => <span>{children}</span>;
 
-export const WithDefaultProps = ({value}) => <div>{value}</div>;
+export const WithDefaultProps = ({value, falsyValue}) => <div>{value},{falsyValue}</div>;
 
 WithDefaultProps.defaultProps = {
   value: 'hi there',
+  falsyValue: false,
 };

--- a/tests/shallow.test.js
+++ b/tests/shallow.test.js
@@ -17,12 +17,15 @@ import {
   SuspenseAsChild,
   SuspenseAsRoot,
   ComponentWithMemo,
+  WithDefaultProps,
+  ComponentWithChildren,
 } from './fixtures/pure-function';
 import {
   BasicClass,
   ClassWithPure,
   ClassWithNull,
   ClassArrayRender,
+  ClassWithDefaultProps,
 } from './fixtures/class';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -125,7 +128,9 @@ it('ignores non-plain objects', () => {
     this._test = true;
   }
 
-  const shallowed = shallow(<WrapperComponent instance={new TestConstructor()} />);
+  const shallowed = shallow(
+    <WrapperComponent instance={new TestConstructor()} />,
+  );
 
   expect(shallowToJson(shallowed)).toMatchSnapshot();
 });
@@ -284,6 +289,46 @@ it('renders a component that has a Suspense as root with Lazy child', () => {
 
 it('renders a component that has a Memo component', () => {
   const wrapper = shallow(<ComponentWithMemo />);
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should not bleed default props from funtional child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <WithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should set prop that has a different value from default prop values of functional component', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <WithDefaultProps value="yeah, man" />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should not bleed default props from class child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ClassWithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should set prop that has a different value from default prop values of class component', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ClassWithDefaultProps value="ah, man" />
+    </ComponentWithChildren>,
+  );
 
   expect(shallowToJson(wrapper)).toMatchSnapshot();
 });

--- a/tests/shallow.test.js
+++ b/tests/shallow.test.js
@@ -293,7 +293,7 @@ it('renders a component that has a Memo component', () => {
   expect(shallowToJson(wrapper)).toMatchSnapshot();
 });
 
-it('should not bleed default props from funtional child component into snapshot', () => {
+it('should bleed default props from functional child component into snapshot without the option', () => {
   const wrapper = shallow(
     <ComponentWithChildren>
       <WithDefaultProps />
@@ -303,10 +303,30 @@ it('should not bleed default props from funtional child component into snapshot'
   expect(shallowToJson(wrapper)).toMatchSnapshot();
 });
 
+it('should not bleed default props from functional child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <WithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
+});
+
 it('should set prop that has a different value from default prop values of functional component', () => {
   const wrapper = shallow(
     <ComponentWithChildren>
       <WithDefaultProps value="yeah, man" />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
+});
+
+it('should bleed default props from class child component into snapshot without the option', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ClassWithDefaultProps />
     </ComponentWithChildren>,
   );
 
@@ -320,7 +340,7 @@ it('should not bleed default props from class child component into snapshot', ()
     </ComponentWithChildren>,
   );
 
-  expect(shallowToJson(wrapper)).toMatchSnapshot();
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
 });
 
 it('should set prop that has a different value from default prop values of class component', () => {
@@ -330,5 +350,5 @@ it('should set prop that has a different value from default prop values of class
     </ComponentWithChildren>,
   );
 
-  expect(shallowToJson(wrapper)).toMatchSnapshot();
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
 });


### PR DESCRIPTION
@adriantoine Hi !

I cherry-pick the @madou commit.
I cherry-pick the @jiangzhu-genie commit in [this PR](https://github.com/adriantoine/enzyme-to-json/pull/112)
And then I add an option `ignoreDefaultProps` to add this behaviour.

This way there is no breaking changes. Fixing https://github.com/adriantoine/enzyme-to-json/issues/99