### PR TITLE
Updating critical severity lodash version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "3.4.1",
   "name": "enzyme-to-json",
   "description": "convert enzyme wrapper to a format compatible with Jest snapshot",
   "main": "index.js",
@@ -40,7 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.12"
+    "lodash": "^4.17.13"
   },
   "peerDependencies": {
     "enzyme": "^3.10.0"


### PR DESCRIPTION
Thanks for your project and all the work you do for the open source community. Unfortunately this project is using an outdated version of `lodash`. Please refer to the screenshot I've attached. This PR should be fairly straight-forward.

<img width="741" alt="Screen Shot 2019-08-27 at 3 04 42 PM" src="https://user-images.githubusercontent.com/2994672/63811756-32f8bb00-c8dd-11e9-8f5f-06a121d531bd.png">
