### PR TITLE
Fix script tags returning null on render

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,7 @@ const renderChildToJson = (child, options) => {
     return null;
   }
 
-  if (child.type === 'tag') {
+  if (['tag', 'script'].includes(child.type)) {
     return applyMap(
       {
         node: child,

--- a/tests/__snapshots__/render.test.js.snap
+++ b/tests/__snapshots__/render.test.js.snap
@@ -141,6 +141,18 @@ Array [
 ]
 `;
 
+exports[`renders an external script 1`] = `
+<script
+  src="http://www.example.com/foo.js"
+/>
+`;
+
+exports[`renders an inline script 1`] = `
+<script>
+  console.log('hi there');
+</script>
+`;
+
 exports[`renders multiple elements as a result of find 1`] = `
 Array [
   <li>

--- a/tests/fixtures/pure-function.js
+++ b/tests/fixtures/pure-function.js
@@ -103,9 +103,21 @@ export const ComponentWithMemo = () => (
 
 export const ComponentWithChildren = ({children}) => <span>{children}</span>;
 
-export const WithDefaultProps = ({value, falsyValue}) => <div>{value},{falsyValue}</div>;
+export const WithDefaultProps = ({value, falsyValue}) => (
+  <div>
+    {value},{falsyValue}
+  </div>
+);
 
 WithDefaultProps.defaultProps = {
   value: 'hi there',
   falsyValue: false,
 };
+
+export const InlineScript = () => (
+  <script dangerouslySetInnerHTML={{__html: `console.log('hi there');`}} />
+);
+
+export const ExternalScript = () => (
+  <script src={'http://www.example.com/foo.js'} />
+);

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -12,6 +12,8 @@ import {
   ArrayRender,
   FragmentAsChild,
   FragmentAsRoot,
+  InlineScript,
+  ExternalScript,
 } from './fixtures/pure-function';
 import {
   BasicClass,
@@ -158,6 +160,18 @@ it('renders a component that has a child fragment', () => {
 
 it('renders a component that has a fragment root', () => {
   const wrapper = render(<FragmentAsRoot />);
+
+  expect(renderToJson(wrapper)).toMatchSnapshot();
+});
+
+it('renders an inline script', () => {
+  const wrapper = render(<InlineScript />);
+
+  expect(renderToJson(wrapper)).toMatchSnapshot();
+});
+
+it('renders an external script', () => {
+  const wrapper = render(<ExternalScript />);
 
   expect(renderToJson(wrapper)).toMatchSnapshot();
 });


### PR DESCRIPTION
Hello

Script tags were skipped on the enzyme render() method as their `type` is `script` and not `tag`.

Fixes #133
