### PR TITLE
Dropping support for Node v4 and Node v5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": "4"
+          "node": "6"
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/adriantoine/enzyme-to-json.git"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
We are dropping support for Node v4 and Node v5 mainly because [Yarn doesn't support those versions anymore](https://github.com/yarnpkg/yarn/issues/6900) so it's impossible to run tests and make sure our library works with those versions.

You can still use `enzyme-to-json` with Node v4 but we can't make sure it's perfectly working.