### PR TITLE
ignoreDefaultProps should work for forwardRef components as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "react-is": "^16.12.0"
   },
   "peerDependencies": {
     "enzyme": "^3.4.0"

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -1,5 +1,6 @@
 import omitBy from 'lodash/omitBy';
 import isNil from 'lodash/isNil';
+import {isValidElementType} from 'react-is';
 
 import {childrenOfNode, propsOfNode} from 'enzyme/build/RSTTraversal';
 
@@ -25,7 +26,7 @@ function getProps(node, options) {
 
     if (
       options.ignoreDefaultProps === true &&
-      typeof node.type === 'function' &&
+      isValidElementType(node.type) &&
       node.type.defaultProps &&
       key in node.type.defaultProps &&
       node.type.defaultProps[key] === val

--- a/tests/__snapshots__/shallow.test.js.snap
+++ b/tests/__snapshots__/shallow.test.js.snap
@@ -293,6 +293,15 @@ exports[`should bleed default props from class child component into snapshot wit
 </span>
 `;
 
+exports[`should bleed default props from forwardRef child component into snapshot without the option 1`] = `
+<span>
+  <ForwardRef
+    falsyValue={false}
+    value="hi mum"
+  />
+</span>
+`;
+
 exports[`should bleed default props from functional child component into snapshot without the option 1`] = `
 <span>
   <WithDefaultProps
@@ -308,6 +317,12 @@ exports[`should not bleed default props from class child component into snapshot
 </span>
 `;
 
+exports[`should not bleed default props from forwardRef child component into snapshot 1`] = `
+<span>
+  <ForwardRef />
+</span>
+`;
+
 exports[`should not bleed default props from functional child component into snapshot 1`] = `
 <span>
   <WithDefaultProps />
@@ -318,6 +333,14 @@ exports[`should set prop that has a different value from default prop values of 
 <span>
   <ClassWithDefaultProps
     value="ah, man"
+  />
+</span>
+`;
+
+exports[`should set prop that has a different value from default prop values of forwardRef component 1`] = `
+<span>
+  <ForwardRef
+    value="yeah, man"
   />
 </span>
 `;

--- a/tests/fixtures/forwardRef.js
+++ b/tests/fixtures/forwardRef.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const ForwardRefWithDefaultProps = React.forwardRef((props, ref) => (
+  <div
+    className={`basic-class ${props.className}`}
+    onClick={function handleOnClick() {}}
+    ref={ref}
+  >
+    <div id="group-id" className="group">
+      <span>{props.children}</span>
+      <span className="empty" />
+    </div>
+  </div>
+));
+
+ForwardRefWithDefaultProps.defaultProps = {
+  value: 'hi mum',
+  falsyValue: false,
+};

--- a/tests/shallow.test.js
+++ b/tests/shallow.test.js
@@ -28,6 +28,10 @@ import {
   ClassWithDefaultProps,
 } from './fixtures/class';
 
+import {
+  ForwardRefWithDefaultProps,
+} from './fixtures/forwardRef';
+
 Enzyme.configure({adapter: new Adapter()});
 
 function WrapperComponent(props) {
@@ -347,6 +351,36 @@ it('should set prop that has a different value from default prop values of class
   const wrapper = shallow(
     <ComponentWithChildren>
       <ClassWithDefaultProps value="ah, man" />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
+});
+
+it('should bleed default props from forwardRef child component into snapshot without the option', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ForwardRefWithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper)).toMatchSnapshot();
+});
+
+it('should not bleed default props from forwardRef child component into snapshot', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ForwardRefWithDefaultProps />
+    </ComponentWithChildren>,
+  );
+
+  expect(shallowToJson(wrapper, { ignoreDefaultProps: true })).toMatchSnapshot();
+});
+
+it('should set prop that has a different value from default prop values of forwardRef component', () => {
+  const wrapper = shallow(
+    <ComponentWithChildren>
+      <ForwardRefWithDefaultProps value="yeah, man" />
     </ComponentWithChildren>,
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4361,6 +4361,11 @@ react-is@^16.10.2, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
+react-is@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.6.0:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.11.0.tgz#72574566496462c808ac449b0287a4c0a1a7d8f8"


### PR DESCRIPTION
This PR addresses an issue I found when I wrapped a component in `React.forwardRef` and it's `defaultProps` appeared in my snapshots despite me having `ignoreDefaultProps` set.

To handle this, I've added the `react-is` library which was explicitly developed by the React JS team to handle this sort of type checking more robustly.

I've written tests and ensured that existing tests don't fail.

