### PR TITLE
Exclude forward ref when using deep mount

### DIFF
--- a/src/mount.js
+++ b/src/mount.js
@@ -1,5 +1,6 @@
 import omitBy from 'lodash/omitBy';
 import isNil from 'lodash/isNil';
+import {ForwardRef} from 'react-is';
 
 import {typeName} from 'enzyme/build/Debug';
 import {childrenOfNode, propsOfNode} from 'enzyme/build/RSTTraversal';
@@ -48,7 +49,10 @@ function internalNodeToJson(node, options) {
     return node.map(child => internalNodeToJson(child, options));
   }
 
-  if (options.mode === 'deep' && typeof node.type === 'function') {
+  if (
+    options.mode === 'deep' &&
+    (typeof node.type === 'function' || node.type.$$typeof === ForwardRef)
+  ) {
     return internalNodeToJson(node.rendered, options);
   }
 

--- a/tests/__snapshots__/mount-deep.test.js.snap
+++ b/tests/__snapshots__/mount-deep.test.js.snap
@@ -227,6 +227,23 @@ exports[`converts pure mount with mixed children 1`] = `
 </div>
 `;
 
+exports[`excludes forwardRef node but renders wrapped component 1`] = `
+<div
+  className="basic-class undefined"
+  onClick={[Function]}
+>
+  <div
+    className="group"
+    id="group-id"
+  >
+    <span />
+    <span
+      className="empty"
+    />
+  </div>
+</div>
+`;
+
 exports[`handles a component which returns null 1`] = `""`;
 
 exports[`includes undefined props 1`] = `

--- a/tests/mount-deep.test.js
+++ b/tests/mount-deep.test.js
@@ -19,6 +19,7 @@ import {
   ClassWithNull,
   ClassArrayRender,
 } from './fixtures/class';
+import {ForwardRefWithDefaultProps} from './fixtures/forwardRef';
 
 Enzyme.configure({adapter: new Adapter()});
 const deepOptions = {mode: 'deep'};
@@ -127,4 +128,10 @@ it('renders multiple elements as a result of find', () => {
   const mounted = mount(<BasicWithAList />);
 
   expect(mountToJson(mounted.find('li'), deepOptions)).toMatchSnapshot();
+});
+
+it('excludes forwardRef node but renders wrapped component', () => {
+  const mounted = mount(<ForwardRefWithDefaultProps />);
+
+  expect(mountToJson(mounted, deepOptions)).toMatchSnapshot();
 });


### PR DESCRIPTION
When using deep mount on a component wrapped with a forwardRef, currently enzyme-to-json includes the forwardRef node in the JSON.

Running the test included here without the added check for forwardRef results in the following snapshot:
```
<ForwardRef
  falsyValue={false}
  value="hi mum"
>
  <div
    className="basic-class undefined"
    onClick={[Function]}
  >
    <div
      className="group"
      id="group-id"
    >
      <span />
      <span
        className="empty"
      />
    </div>
  </div>
</ForwardRef>
```

Since the deep mode should only include DOM nodes, this PR adds a check to exclude the forwardRef node but include the output of the wrapped component.